### PR TITLE
Fix Codex CLI OTLP integration (HTTP response flush + correct config)

### DIFF
--- a/AgentNotch/Core/Telemetry/OTLPHTTPServer.swift
+++ b/AgentNotch/Core/Telemetry/OTLPHTTPServer.swift
@@ -67,6 +67,7 @@ private final class HTTPConnectionHandler {
     private var contentLength: Int = 0
     private var route: OTLPHTTPServer.Route = .other
     private var contentEncoding: String?
+    private var didFinish = false
 
     init(
         connection: NWConnection,
@@ -124,11 +125,12 @@ private final class HTTPConnectionHandler {
         buffer.removeSubrange(0..<contentLength)
         let decodedBody = decodeBodyIfNeeded(body)
         onRequest(.init(route: route, body: decodedBody))
-        sendResponse(status: 200)
-        finish()
+        sendResponseAndFinish(status: 200)
     }
 
     private func finish() {
+        guard !didFinish else { return }
+        didFinish = true
         connection.cancel()
         onComplete(self)
     }
@@ -155,9 +157,14 @@ private final class HTTPConnectionHandler {
         }
     }
 
-    private func sendResponse(status: Int) {
-        let response = "HTTP/1.1 \(status) OK\r\nContent-Length: 0\r\n\r\n"
-        connection.send(content: response.data(using: .utf8), completion: .contentProcessed { _ in })
+    private func sendResponseAndFinish(status: Int) {
+        let response = "HTTP/1.1 \(status) OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        connection.send(content: response.data(using: .utf8), completion: .contentProcessed { [weak self] error in
+            if let error {
+                self?.onError("OTLP HTTP send error: \(error)")
+            }
+            self?.finish()
+        })
     }
 
     private func decodeBodyIfNeeded(_ data: Data) -> Data {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,22 @@ export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
 
 ### Setup with Codex
 
-Configure Codex to send OpenTelemetry data to `localhost:4318`.
+AgentNotch listens for **OTLP/HTTP** on port **4318** by default, and currently decodes **OTLP logs** (`/v1/logs`) and **metrics** (`/v1/metrics`).
+
+Codex CLI (v0.79+) uses `~/.codex/config.toml` with an `[otel]` section (not `[telemetry]`). Add:
+
+```toml
+[analytics]
+enabled = true
+
+[otel]
+# AgentNotch currently does not decode OTLP traces, so disable trace export to avoid noisy errors.
+trace_exporter = "none"
+
+[otel.exporter.otlp-http]
+endpoint = "http://localhost:4318/v1/logs"
+protocol = "binary"
+```
 
 ### Using the App
 


### PR DESCRIPTION
This PR makes AgentNotch work cleanly with Codex CLI (v0.79+):

- Fixes OTLP HTTP server to send and flush the HTTP response before closing the connection (prevents Codex OTLP exporter errors like IncompleteMessage).
- Updates README with correct Codex CLI OpenTelemetry config (Codex uses [otel], not [telemetry]) and points export to OTLP logs (/v1/logs), which AgentNotch currently decodes.

Tested locally with Codex CLI emitting OTLP logs to localhost:4318.