### PR TITLE
fix: discover all active sessions including multiple per workspace

### DIFF
--- a/AgentNotch/Core/ClaudeCode/ClaudeCodeManager.swift
+++ b/AgentNotch/Core/ClaudeCode/ClaudeCodeManager.swift
@@ -191,8 +191,8 @@ final class ClaudeCodeManager: ObservableObject {
             debugLog("[ClaudeCode] No IDE dir - checking for terminal sessions")
         }
 
-        // If no IDE sessions, discover from recently active project JSONL files
-        if sessions.isEmpty && fm.fileExists(atPath: projectsDir.path) {
+        // Also discover from recently active project JSONL files (terminal sessions)
+        if fm.fileExists(atPath: projectsDir.path) {
             debugLog("[ClaudeCode] Scanning projects dir for active terminal sessions...")
 
             do {

--- a/AgentNotch/Core/ClaudeCode/ClaudeCodeManager.swift
+++ b/AgentNotch/Core/ClaudeCode/ClaudeCodeManager.swift
@@ -206,7 +206,9 @@ final class ClaudeCodeManager: ObservableObject {
                 let recentThreshold = Date().addingTimeInterval(-300) // 5 minutes
 
                 for projectDir in projectDirs {
-                    if let jsonlFile = findCurrentSessionFile(in: projectDir) {
+                    let jsonlFiles = findActiveSessionFiles(in: projectDir)
+
+                    for jsonlFile in jsonlFiles {
                         let attrs = try? fm.attributesOfItem(atPath: jsonlFile.path)
                         let modDate = attrs?[.modificationDate] as? Date ?? .distantPast
 
@@ -215,14 +217,17 @@ final class ClaudeCodeManager: ObservableObject {
                             let workspacePath = projectDir.lastPathComponent
                                 .replacingOccurrences(of: "-", with: "/")
 
+                            // Use sessionId from filename for unique identification
+                            let sessionId = jsonlFile.deletingPathExtension().lastPathComponent
+
                             let session = ClaudeSession(
                                 pid: 0,  // Terminal sessions don't have a single PID
-                                workspaceFolders: [workspacePath],
+                                workspaceFolders: ["\(workspacePath)#\(sessionId)"],
                                 ideName: "Terminal",
                                 transport: nil,
                                 runningInWindows: nil
                             )
-                            debugLog("[ClaudeCode] Terminal session: \(session.displayName) (modified \(Int(-modDate.timeIntervalSinceNow))s ago)")
+                            debugLog("[ClaudeCode] Terminal session: \(session.displayName) [id: \(sessionId.prefix(8))...] (modified \(Int(-modDate.timeIntervalSinceNow))s ago)")
                             sessions.append(session)
                         }
                     }
@@ -361,9 +366,22 @@ final class ClaudeCodeManager: ObservableObject {
         }
 
         let projectDir = projectsDir.appendingPathComponent(projectKey)
-        guard let jsonlFile = findCurrentSessionFile(in: projectDir) else {
-            debugLog("[ClaudeCode] No session file found for project: \(projectKey)")
-            return
+
+        // For terminal sessions, use the specific session file; for IDE, use most recent
+        let jsonlFile: URL
+        if let terminalId = session.terminalSessionId {
+            jsonlFile = projectDir.appendingPathComponent("\(terminalId).jsonl")
+            guard FileManager.default.fileExists(atPath: jsonlFile.path) else {
+                debugLog("[ClaudeCode] Session file not found: \(terminalId).jsonl")
+                return
+            }
+        } else {
+            let activeFiles = findActiveSessionFiles(in: projectDir)
+            guard let firstFile = activeFiles.first else {
+                debugLog("[ClaudeCode] No session file found for project: \(projectKey)")
+                return
+            }
+            jsonlFile = firstFile
         }
 
         debugLog("[ClaudeCode] Watching session file: \(jsonlFile.path)")
@@ -443,7 +461,16 @@ final class ClaudeCodeManager: ObservableObject {
         if let projectKey = session.projectKey {
             debugLog("[ClaudeCode]   - Project key: \(projectKey)")
             let directPath = projectsDir.appendingPathComponent(projectKey)
-            if let file = findCurrentSessionFile(in: directPath) {
+
+            // For terminal sessions, use the specific session file
+            if let terminalId = session.terminalSessionId {
+                let specificFile = directPath.appendingPathComponent("\(terminalId).jsonl")
+                if FileManager.default.fileExists(atPath: specificFile.path) {
+                    projectDir = directPath
+                    jsonlFile = specificFile
+                    debugLog("[ClaudeCode]   - Found terminal session file: \(terminalId).jsonl")
+                }
+            } else if let file = findActiveSessionFiles(in: directPath).first {
                 projectDir = directPath
                 jsonlFile = file
                 debugLog("[ClaudeCode]   - Found via direct match: \(directPath.path)")
@@ -455,9 +482,12 @@ final class ClaudeCodeManager: ObservableObject {
             debugLog("[ClaudeCode]   - Direct match failed, scanning all projects...")
             let fm = FileManager.default
 
+            // Strip session fragment for comparison
+            let cleanWorkspace = workspace.components(separatedBy: "#").first ?? workspace
+            let normalizedWorkspace = cleanWorkspace.lowercased()
+
             if let projectDirs = try? fm.contentsOfDirectory(at: projectsDir, includingPropertiesForKeys: nil) {
                 // Look for directory that matches the workspace path
-                let normalizedWorkspace = workspace.lowercased()
                 for dir in projectDirs {
                     // Convert dir name back to path: "-Users-foo-project" -> "/Users/foo/project"
                     let dirName = dir.lastPathComponent
@@ -465,7 +495,16 @@ final class ClaudeCodeManager: ObservableObject {
                     // Handle leading dash correctly (absolute paths start with /)
                     let normalizedDirPath = dirPath.hasPrefix("/") ? dirPath : "/" + dirPath
                     if normalizedDirPath.lowercased() == normalizedWorkspace {
-                        if let file = findCurrentSessionFile(in: dir) {
+                        // For terminal sessions, use the specific session file
+                        if let terminalId = session.terminalSessionId {
+                            let specificFile = dir.appendingPathComponent("\(terminalId).jsonl")
+                            if fm.fileExists(atPath: specificFile.path) {
+                                projectDir = dir
+                                jsonlFile = specificFile
+                                debugLog("[ClaudeCode]   - Found terminal session via scan: \(terminalId).jsonl")
+                                break
+                            }
+                        } else if let file = findActiveSessionFiles(in: dir).first {
                             projectDir = dir
                             jsonlFile = file
                             debugLog("[ClaudeCode]   - Found via scan: \(dir.path)")
@@ -975,17 +1014,17 @@ final class ClaudeCodeManager: ObservableObject {
         sessionsNeedingPermission = needingPermission
     }
 
-    private func findCurrentSessionFile(in projectDir: URL) -> URL? {
+    private func findActiveSessionFiles(in projectDir: URL) -> [URL] {
         let fm = FileManager.default
 
         guard fm.fileExists(atPath: projectDir.path) else {
-            debugLog("[ClaudeCode] findCurrentSessionFile: directory does not exist: \(projectDir.path)")
-            return nil
+            debugLog("[ClaudeCode] findActiveSessionFiles: directory does not exist: \(projectDir.path)")
+            return []
         }
 
         do {
             let allFiles = try fm.contentsOfDirectory(at: projectDir, includingPropertiesForKeys: [.contentModificationDateKey])
-            debugLog("[ClaudeCode] findCurrentSessionFile: \(allFiles.count) files in \(projectDir.lastPathComponent)")
+            debugLog("[ClaudeCode] findActiveSessionFiles: \(allFiles.count) files in \(projectDir.lastPathComponent)")
 
             let files = allFiles
                 .filter { $0.pathExtension == "jsonl" && !$0.lastPathComponent.hasPrefix("agent-") }
@@ -995,15 +1034,13 @@ final class ClaudeCodeManager: ObservableObject {
                     return date1 > date2
                 }
 
-            debugLog("[ClaudeCode] findCurrentSessionFile: \(files.count) JSONL files found")
-            if let first = files.first {
-                debugLog("[ClaudeCode] findCurrentSessionFile: using \(first.lastPathComponent)")
-            }
+            debugLog("[ClaudeCode] findActiveSessionFiles: \(files.count) JSONL files found")
 
-            return files.first
+            // Return all recent files, not just the first one
+            return files
         } catch {
-            debugLog("[ClaudeCode] findCurrentSessionFile: error: \(error)")
-            return nil
+            debugLog("[ClaudeCode] findActiveSessionFiles: error: \(error)")
+            return []
         }
     }
 

--- a/AgentNotch/Models/ClaudeCodeModels.swift
+++ b/AgentNotch/Models/ClaudeCodeModels.swift
@@ -23,16 +23,27 @@ struct ClaudeSession: Identifiable, Codable, Equatable {
     /// Claude Code uses path with "/" replaced by "-" as the project directory name
     var projectKey: String? {
         guard let workspace = workspaceFolders.first else { return nil }
+        // Strip session fragment if present (e.g., /path#sessionId -> /path)
+        let cleanPath = workspace.components(separatedBy: "#").first ?? workspace
         // Claude Code escapes the path: "/" -> "-", but keeps leading "-" for absolute paths
         // e.g., /Users/foo/project -> -Users-foo-project
-        return workspace
+        return cleanPath
             .replacingOccurrences(of: "/", with: "-")
     }
 
     /// Display name for UI (last folder component)
     var displayName: String {
         guard let workspace = workspaceFolders.first else { return "Unknown" }
-        return URL(fileURLWithPath: workspace).lastPathComponent
+        // Strip session fragment if present (e.g., /path#sessionId -> /path)
+        let cleanPath = workspace.components(separatedBy: "#").first ?? workspace
+        return URL(fileURLWithPath: cleanPath).lastPathComponent
+    }
+
+    /// Terminal session ID extracted from workspace fragment (nil for IDE sessions)
+    var terminalSessionId: String? {
+        guard let workspace = workspaceFolders.first else { return nil }
+        let parts = workspace.components(separatedBy: "#")
+        return parts.count > 1 ? parts[1] : nil
     }
 }
 

--- a/AgentNotch/Models/ClaudeCodeModels.swift
+++ b/AgentNotch/Models/ClaudeCodeModels.swift
@@ -11,7 +11,7 @@ import Foundation
 
 /// Represents an active Claude Code IDE session from ~/.claude/ide/*.lock
 struct ClaudeSession: Identifiable, Codable, Equatable {
-    var id: String { workspaceFolders.first ?? "\(pid)" }
+    var id: String { "\(ideName):\(workspaceFolders.first ?? "\(pid)")" }
 
     let pid: Int
     let workspaceFolders: [String]


### PR DESCRIPTION
## Summary

This PR fixes two related issues with session discovery:

1. **Terminal sessions excluded when IDE sessions exist** - The `sessions.isEmpty` guard caused terminal session discovery to only run as a fallback, never alongside IDE sessions.

2. **Only one session shown per workspace** - The `findCurrentSessionFile` function returned only the most recent JSONL file, collapsing multiple active sessions in the same workspace into one.

## Changes

- Remove `sessions.isEmpty` guard to discover IDE and terminal sessions concurrently
- Add `ideName:` prefix to session IDs (e.g., `Cursor:/path`, `Terminal:/path`) to prevent collisions
- Rename `findCurrentSessionFile` → `findActiveSessionFiles` returning all active JSONL files
- Embed sessionId (JSONL filename UUID) in workspace as fragment for unique identification
- Update `projectKey` and `displayName` to strip session fragment for clean paths
- Add `terminalSessionId` computed property for targeted file watching

## Result

Users can now see ALL active Claude Code sessions:
- Multiple IDE windows (Cursor, VS Code, etc.)
- Multiple terminal sessions
- Both IDE and terminal sessions simultaneously
- Multiple sessions in the same workspace

## Testing

Manual verification:
1. Open Cursor with Claude Code extension
2. Open multiple terminal `claude` sessions in same directory
3. All sessions now appear in AgentNotch notch

---

🤖 Generated with [Claude Code](https://claude.ai/code)